### PR TITLE
VIDLA-4471 - Fixed isDomElement util function to work in iFrame context

### DIFF
--- a/src/scripts/utils/dom.js
+++ b/src/scripts/utils/dom.js
@@ -177,7 +177,7 @@ dom.remove = function removeNode(node){
 };
 
 dom.isDomElement = function isDomElement(o) {
-  return o instanceof Element;
+  return o instanceof Element || (parent && parent.Element && o instanceof parent.Element);     // If MOL is loaded in an iFrame, a DOM Element may be passed in from the parent document - check for that, too
 };
 
 dom.click = function(el, handler) {


### PR DESCRIPTION
Updated dom.isDomElement to work for Elements passed in from a parent document to MOL in an iFrame